### PR TITLE
Use api.bunnies.io instead of the old rest.bunnies.io

### DIFF
--- a/compsoc/static/compsoc/css/override.css
+++ b/compsoc/static/compsoc/css/override.css
@@ -246,7 +246,7 @@ body {
 #error-page {
     text-align: center;
     padding: 40px 0px;
-    background-image: url("https://rest.bunnies.io/v1/gif/random.gif");
+    background-image: url("https://api.bunnies.io/v1/gif/random.gif");
     background-position: center;
 }
 


### PR DESCRIPTION
Tiny PR just to use the correct domain for bunnies.io - I'd used the old one by mistake previously and it was redirecting.